### PR TITLE
Support DUB package manager.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+    "name":        "mustache-d",
+    "description": "Mustache template engine for D.",
+    "authors":     ["Masahiro Nakagawa"],
+    "homepage":    "https://github.com/repeatedly/mustache-d",
+    "license":     "Boost Software License, Version 1.0",
+    "copyright":   "Copyright (c) 2011 Masahiro Nakagawa",
+    
+    "importPaths": ["src"],
+    "dflags-dmd":  ["-w", "-d", "-property"],
+    "targetType":  "library"
+}


### PR DESCRIPTION
With this, mustache-d can be used with DUB: https://github.com/rejectedsoftware/dub

If mustache-d is then registered at http://registry.vibed.org/publish (which I can do if you'd like), then other DUB users can use mustache-d in their projects simply by including it in the "dependencies" section of their project's DUB configuration file.
