### PR TITLE
Fixed: Inverted sections render on non-empty lists.

### DIFF
--- a/src/mustache.d
+++ b/src/mustache.d
@@ -693,8 +693,10 @@ struct MustacheEngine(String = string) if (isSomeString!(String))
                         if (node.flag)
                             renderImpl(node.childs, context, sink);
                     } else {
-                        foreach (sub; list)
-                            renderImpl(node.childs, sub, sink);
+                        if (!node.flag) {
+                            foreach (sub; list)
+                                renderImpl(node.childs, sub, sink);
+                        }
                     }
                     break;
                 }


### PR DESCRIPTION
This fixes the following issue:

{{{
import mustache;
import std.stdio;

alias MustacheEngine!(string) Mustache;

void main()
{
    Mustache mustache;
    auto context = new Mustache.Context;
    context.addSubContext("section")["foo"] = "bar";

```
auto mustacheTemplate = "{{^section}}This shouldn't be seen.{{/section}}";
stdout.rawWrite(mustache.renderString(mustacheTemplate, context));
```

}
}}}

Expected output:
(empty)

Actual output:
{{{This shouldn't be seen.}}}
