### PR TITLE
In compile(), reduce excess implicit reallocate-and-copy of stack.

### DIFF
--- a/src/mustache.d
+++ b/src/mustache.d
@@ -877,7 +877,7 @@ struct MustacheEngine(String = string) if (isSomeString!(String))
                 auto key = src[1..end].strip();
                 if (stack.empty)
                     throw new MustacheException(to!string(key) ~ " is unopened");
-                auto memo = stack.back; stack.popBack();
+                auto memo = stack.back; stack.popBack(); stack.assumeSafeAppend();
                 if (key != memo.key)
                     throw new MustacheException(to!string(key) ~ " is different from expected " ~ to!string(memo.key));
 


### PR DESCRIPTION
If you use an array as a stack and don't make use of [assumeSafeAppend](http://dlang.org/phobos/object.html#assumeSafeAppend), then you'll get a bunch of excess reallocations and copying. See [this link](http://semitwist.com/articles/article/view/don-t-use-arrays-as-stacks) for a deeper explanation.
