### PR TITLE
Simplify fetchSection and avoid double-lookups.

### DIFF
--- a/src/mustache.d
+++ b/src/mustache.d
@@ -674,10 +674,10 @@ struct MustacheEngine(String = string) if (isSomeString!(String))
                     break;
                 case Context.SectionType.var:
                     auto var = section.var;
-					auto sub = new Context(context);
-					foreach (k, v; var)
-						sub[k] = v;
-					renderImpl(node.childs, sub, sink);
+                    auto sub = new Context(context);
+                    foreach (k, v; var)
+                        sub[k] = v;
+                    renderImpl(node.childs, sub, sink);
                     break;
                 case Context.SectionType.func:
                     auto func = section.func;
@@ -685,10 +685,10 @@ struct MustacheEngine(String = string) if (isSomeString!(String))
                     break;
                 case Context.SectionType.list:
                     auto list = section.list;
-					if (!node.flag) {
-						foreach (sub; list)
-							renderImpl(node.childs, sub, sink);
-					}
+                    if (!node.flag) {
+                        foreach (sub; list)
+                            renderImpl(node.childs, sub, sink);
+                    }
                     break;
                 }
                 break;


### PR DESCRIPTION
As requested. Note that this is slightly different from the first commit in #14 because I was able to simplify the render function a little further (eliminating newly-dead code).
