### PR TITLE
Fixed deprecation errors in dub

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -4,9 +4,8 @@
     "authors":     ["Masahiro Nakagawa"],
     "homepage":    "https://github.com/repeatedly/mustache-d",
     "license":     "Boost Software License, Version 1.0",
-    "copyright":   "Copyright (c) 2011 Masahiro Nakagawa",
-    
+    "copyright":   "Copyright (c) 2011-. Masahiro Nakagawa",
+    "buildRequirements": ["silenceDeprecations"],
     "importPaths": ["src"],
-    "dflags-dmd":  ["-w", "-d", "-property"],
     "targetType":  "library"
 }


### PR DESCRIPTION
DUB draws these errors about 3 times due to the use of D flags.

```
## Warning for package mustache-d ##

The following compiler flags have been specified in the package description
file. They are handled by DUB and direct use in packages is discouraged.
Alternatively, you can set the DFLAGS environment variable to pass custom flags
to the compiler, or use one of the suggestions below:

-w: Use "buildRequirements" to control warning behavior
-d: Use the "buildRequirements" field to control deprecation behavior
-property: Using this flag may break building of dependencies and it will probably be removed from DMD in the future
```
