### PR TITLE
Add Meson build configuration

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,26 @@
+project('mustache-d', 'd')
+
+project_version      = '0.1.1'
+project_soversion    = '0'
+
+src_dir = include_directories('src/')
+pkgc = import('pkgconfig')
+
+mustache_src = [
+    'src/mustache.d'
+]
+install_headers(mustache_src, subdir: 'd/mustache-d')
+
+mustache_lib = static_library('mustache-d',
+        [mustache_src],
+        include_directories: [src_dir],
+        install: true,
+        version: project_version,
+        soversion: project_soversion
+)
+pkgc.generate(name: 'mustache-d',
+              libraries: mustache_lib,
+              subdirs: 'd/mustache-d',
+              version: project_version,
+              description: 'Mustache template engine for D.'
+)


### PR DESCRIPTION
We use this Meson build config to build the Mustache-d Debian package, since dub isn't a working choice at time to build distribution packages, and the Makefile wasn't working either.
You can find out more about Meson here: http://mesonbuild.com/
Maybe others will find this useful as well when it is upstreamed.

How to test:
```ShellSession
mkdir build && cd build
meson ..
ninja
sudo ninja install
```
