### PR TITLE
Created option to dynamically finding a file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -36,6 +36,10 @@ File extenstion of Mustache template. Default is "mustache".
 
 root path to read Mustache template. Default is "."(current directory).
 
+* findPath(string delegate(string))
+
+callback to dynamically find the path do a Mustache template. Default is none. Mutually exclusive with the `path` option.
+
 * level(CacheLevel)
 
 Cache level for Mustache's in-memory cache. Default is "check". See DDoc.


### PR DESCRIPTION
Created a option called findPath which is a delegate that receives the name of the template and should return the path to the template. If this option is not set, the default behavior of using the path option to build the template path will be used.